### PR TITLE
🚀 Remove Annotations and Tag All text elements (optionally)

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 cd "$(dirname "$0")" || exit 1
-cd .. || exit 1
 
 printf "Formatting Code 🧹\n"
 poetry run black .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tarsier"
-version = "0.3.3"
+version = "0.3.4"
 description = "Vision utilities for web interaction agents"
 authors = ["Rohan Pandey", "Adam Watkins", "Asim Shrestha"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tarsier"
-version = "0.3.4"
+version = "0.4.0"
 description = "Vision utilities for web interaction agents"
 authors = ["Rohan Pandey", "Adam Watkins", "Asim Shrestha"]
 readme = "README.md"

--- a/tarsier/adapter/_base.py
+++ b/tarsier/adapter/_base.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
 from typing import Any
 
+from tarsier.adapter.types import ViewPortSize
+
 
 class BrowserAdapter(ABC):
     @abstractmethod
@@ -13,4 +15,8 @@ class BrowserAdapter(ABC):
 
     @abstractmethod
     async def set_viewport_size(self, width: int, height: int) -> None:
+        pass
+
+    @abstractmethod
+    async def get_viewport_size(self) -> ViewPortSize:
         pass

--- a/tarsier/adapter/playwright.py
+++ b/tarsier/adapter/playwright.py
@@ -4,9 +4,12 @@ from playwright.async_api import Page as PageAsync
 from playwright.sync_api import Page as PageSync
 
 from tarsier.adapter._base import BrowserAdapter
+from tarsier.adapter.types import ViewPortSize
 
 
 class PlaywrightSyncAdapter(BrowserAdapter):
+    STRIP_RETURN = "return window."
+
     def __init__(self, page: PageSync):
         self._page = page
         raise NotImplementedError(
@@ -14,6 +17,9 @@ class PlaywrightSyncAdapter(BrowserAdapter):
         )
 
     async def run_js(self, js: str) -> Any:
+        if js.startswith(self.STRIP_RETURN):
+            js = js[len(self.STRIP_RETURN) :]
+
         return self._page.evaluate(js)
 
     async def take_screenshot(self) -> bytes:
@@ -22,12 +28,24 @@ class PlaywrightSyncAdapter(BrowserAdapter):
     async def set_viewport_size(self, width: int, height: int) -> None:
         self._page.set_viewport_size({"width": width, "height": height})
 
+    async def get_viewport_size(self) -> ViewPortSize:
+        width, height, scroll_height = await self.run_js(
+            "[window.innerWidth, window.innerHeight, document.documentElement.scrollHeight]"
+        )
+
+        return {"width": width, "height": height, "content_height": scroll_height}
+
 
 class PlaywrightAsyncAdapter(BrowserAdapter):
+    STRIP_RETURN = "return window."
+
     def __init__(self, page: PageAsync):
         self._page = page
 
     async def run_js(self, js: str) -> Any:
+        if js.startswith(self.STRIP_RETURN):
+            js = js[len(self.STRIP_RETURN) :]
+
         return await self._page.evaluate(js)
 
     async def take_screenshot(self) -> bytes:
@@ -35,3 +53,10 @@ class PlaywrightAsyncAdapter(BrowserAdapter):
 
     async def set_viewport_size(self, width: int, height: int) -> None:
         await self._page.set_viewport_size({"width": width, "height": height})
+
+    async def get_viewport_size(self) -> ViewPortSize:
+        width, height, scroll_height = await self.run_js(
+            "[window.innerWidth, window.innerHeight, document.documentElement.scrollHeight]"
+        )
+
+        return {"width": width, "height": height, "content_height": scroll_height}

--- a/tarsier/adapter/selenium.py
+++ b/tarsier/adapter/selenium.py
@@ -4,6 +4,7 @@ from typing import Any
 from selenium.webdriver.remote.webdriver import WebDriver
 
 from tarsier.adapter._base import BrowserAdapter
+from tarsier.adapter.types import ViewPortSize
 
 
 class SeleniumAdapter(BrowserAdapter):
@@ -18,3 +19,8 @@ class SeleniumAdapter(BrowserAdapter):
 
     async def set_viewport_size(self, width: int, height: int) -> None:
         self.driver.set_window_size(width, height)
+
+    async def get_viewport_size(self) -> ViewPortSize:
+        script = "return [window.innerWidth, window.innerHeight, document.documentElement.scrollHeight];"
+        width, height, content_height = self.driver.execute_script(script)
+        return {"width": width, "height": height, "content_height": content_height}

--- a/tarsier/adapter/types.py
+++ b/tarsier/adapter/types.py
@@ -1,7 +1,13 @@
-from typing import Union
+from typing import TypedDict, Union
 
 from playwright.async_api import Page as PageAsync
 from playwright.sync_api import Page as PageSync
 from selenium.webdriver.remote.webdriver import WebDriver
 
 AnyDriver = Union[WebDriver, PageSync, PageAsync]
+
+
+class ViewPortSize(TypedDict):
+    width: int
+    height: int
+    content_height: int

--- a/tarsier/core.py
+++ b/tarsier/core.py
@@ -16,15 +16,15 @@ class Tarsier(ITarsier):
         with open(self._JS_TAG_UTILS, "r") as f:
             self._js_utils = f.read()
 
-    async def page_to_image(self, driver: AnyDriver, tagUninteractableText: bool = False) -> Tuple[bytes, Dict[int, str]]:
+    async def page_to_image(self, driver: AnyDriver, tag_text_elements: bool = False) -> Tuple[bytes, Dict[int, str]]:
         adapter = adapter_factory(driver)
-        tag_to_xpath = await self._tag_page(adapter, tagUninteractableText)
+        tag_to_xpath = await self._tag_page(adapter, tag_text_elements)
         screenshot = await self._take_screenshot(adapter)
         await self._remove_tags(adapter)
         return screenshot, tag_to_xpath
 
-    async def page_to_text(self, driver: AnyDriver, tagUninteractableText: bool = False) -> Tuple[str, TagToXPath]:
-        image, tag_to_xpath = await self.page_to_image(driver, tagUninteractableText)
+    async def page_to_text(self, driver: AnyDriver, tag_text_elements: bool = False) -> Tuple[str, TagToXPath]:
+        image, tag_to_xpath = await self.page_to_image(driver, tag_text_elements)
         page_text = self._run_ocr(image)
         return page_text, tag_to_xpath
 
@@ -49,11 +49,11 @@ class Tarsier(ITarsier):
         return page_text
 
     async def _tag_page(
-        self, adapter: BrowserAdapter, tagUninteractableText: bool = False
+        self, adapter: BrowserAdapter, tag_text_elements: bool = False
     ) -> Dict[int, str]:
         await adapter.run_js(self._js_utils)
 
-        script = f"tagifyWebpage({str(tagUninteractableText).lower()});"
+        script = f"tagifyWebpage({str(tag_text_elements).lower()});"
         if isinstance(adapter, SeleniumAdapter):
             script = f"return window.{script}"
 

--- a/tarsier/core.py
+++ b/tarsier/core.py
@@ -16,30 +16,30 @@ class Tarsier(ITarsier):
         with open(self._JS_TAG_UTILS, "r") as f:
             self._js_utils = f.read()
 
-    async def page_to_image(self, driver: AnyDriver, tag_text_elements: bool = False) -> Tuple[bytes, Dict[int, str]]:
+    async def page_to_image(
+        self, driver: AnyDriver, tag_text_elements: bool = False
+    ) -> Tuple[bytes, Dict[int, str]]:
         adapter = adapter_factory(driver)
         tag_to_xpath = await self._tag_page(adapter, tag_text_elements)
         screenshot = await self._take_screenshot(adapter)
         await self._remove_tags(adapter)
         return screenshot, tag_to_xpath
 
-    async def page_to_text(self, driver: AnyDriver, tag_text_elements: bool = False) -> Tuple[str, TagToXPath]:
+    async def page_to_text(
+        self, driver: AnyDriver, tag_text_elements: bool = False
+    ) -> Tuple[str, TagToXPath]:
         image, tag_to_xpath = await self.page_to_image(driver, tag_text_elements)
         page_text = self._run_ocr(image)
         return page_text, tag_to_xpath
 
     @staticmethod
     async def _take_screenshot(adapter: BrowserAdapter) -> bytes:
-        # TODO: scroll & stitch here, don't do viewport resizing
-        script = "() => [window.innerWidth, window.innerHeight, document.documentElement.scrollHeight];"
-        if isinstance(adapter, SeleniumAdapter):
-            script = f"return [window.innerWidth, window.innerHeight, document.documentElement.scrollHeight];"
+        viewport = await adapter.get_viewport_size()
+        default_width = viewport["width"]
 
-        default_width, default_height, content_height = await adapter.run_js(script)
-
-        await adapter.set_viewport_size(default_width, content_height)
+        await adapter.set_viewport_size(default_width, viewport["content_height"])
         screenshot = await adapter.take_screenshot()
-        await adapter.set_viewport_size(default_width, default_height)
+        await adapter.set_viewport_size(default_width, viewport["height"])
 
         return screenshot
 
@@ -53,19 +53,12 @@ class Tarsier(ITarsier):
     ) -> Dict[int, str]:
         await adapter.run_js(self._js_utils)
 
-        script = f"tagifyWebpage({str(tag_text_elements).lower()});"
-        if isinstance(adapter, SeleniumAdapter):
-            script = f"return window.{script}"
-
+        script = f"return window.tagifyWebpage({str(tag_text_elements).lower()});"
         tag_to_xpath = await adapter.run_js(script)
+
         return {int(key): value for key, value in tag_to_xpath.items()}
 
     async def _remove_tags(self, adapter: BrowserAdapter) -> None:
-        # await adapter.run_js(self._js_utils)
-
-        script = "removeTags();"
-        if isinstance(adapter, SeleniumAdapter):
-            script = f"return window.{script}"
+        script = "return window.removeTags();"
 
         await adapter.run_js(script)
-        return None

--- a/tarsier/tag_utils.js
+++ b/tarsier/tag_utils.js
@@ -178,6 +178,6 @@ window.tagifyWebpage = (tagLeafTexts = false) => {
 
 
 window.removeTags = () => {
-    const tags = document.querySelectorAll('#__tarsier_tag');
+    const tags = document.querySelectorAll('#__tarsier_id');
     tags.forEach(tag => tag.remove());
 }

--- a/tests/adapter/test_playwright.py
+++ b/tests/adapter/test_playwright.py
@@ -41,3 +41,15 @@ async def test_set_viewport_size(mocker):
     mock_page.set_viewport_size.assert_called_once_with(
         {"width": width, "height": height}
     )
+
+
+@pytest.mark.asyncio
+async def test_get_viewport_size_returns_correct_values(async_page: Page):
+    adapter = PlaywrightAsyncAdapter(async_page)
+
+    await adapter.set_viewport_size(1920, 1080)
+    viewport = await adapter.get_viewport_size()
+
+    assert viewport["width"] == 1920
+    assert viewport["height"] == 1080
+    assert viewport["content_height"] == 1080

--- a/tests/adapter/test_selenium.py
+++ b/tests/adapter/test_selenium.py
@@ -1,0 +1,16 @@
+import pytest
+from selenium.webdriver.remote.webdriver import WebDriver
+
+from tarsier.adapter import SeleniumAdapter
+
+
+@pytest.mark.asyncio
+async def test_get_viewport_size_returns_correct_values(chrome_driver: WebDriver):
+    adapter = SeleniumAdapter(chrome_driver)
+
+    await adapter.set_viewport_size(1920, 1080)
+    viewport = await adapter.get_viewport_size()
+
+    assert viewport["width"] == 1920
+    assert viewport["height"] == 1080
+    assert viewport["content_height"] == 1080


### PR DESCRIPTION
- Tarsier now tags using spans with a unique ID (allows easy removal)
- Removes annotations after tarsier is done with them
- Adds option to tag all text elements

Bonus: Since we are now annotating using spans we can now add CSS to the annotations so that vision model can see them easier

fixes #5 #7 