### PR TITLE
Bugfix/ocr provider naming

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tarsier"
-version = "0.6.1"
+version = "0.6.2"
 description = "Vision utilities for web interaction agents"
 authors = ["Rohan Pandey", "Adam Watkins", "Asim Shrestha"]
 readme = "README.md"

--- a/tarsier/__main__.py
+++ b/tarsier/__main__.py
@@ -74,4 +74,4 @@ def parse_args() -> argparse.Namespace:
 
 if __name__ == "__main__":
     args = parse_args()
-    asyncio.run(main(args.credentials_path, args.url, args.verbose, args.ocr_service))
+    asyncio.run(main(args.credentials_path, args.url, args.verbose, args.ocr_provider))


### PR DESCRIPTION
Minor bugfix 
Change was made to rename ocr_service input argument to ocr_provider -- was missed in the CLI invocation in __main__.py