### PR TITLE
bugfix: switch order of screenshot and tag removal 

### DIFF
--- a/tarsier/core.py
+++ b/tarsier/core.py
@@ -36,9 +36,9 @@ class Tarsier(ITarsier):
         tag_to_xpath = (
             await self._tag_page(adapter, tag_text_elements) if not tagless else {}
         )
-        screenshot = await self._take_screenshot(adapter)
         if not tagless and not keep_tags_showing:
             await self._remove_tags(adapter)
+        screenshot = await self._take_screenshot(adapter)
         return screenshot, tag_to_xpath if not tagless else {}
 
     async def page_to_text(


### PR DESCRIPTION
I'm working with this tool and utilizing the screenshot functionality and realized that the tag removal happens in the "wrong" order. Not sure if there is a broader reasoning behind this, or maybe just a mistake but this PR produces the results I actually need/want when using `page_to_image` with tagless passed in 