### PR TITLE
Fix errors in the LlamaIndex Cookbook Example

### DIFF
--- a/cookbook/llama-index-web-agent.ipynb
+++ b/cookbook/llama-index-web-agent.ipynb
@@ -179,7 +179,7 @@
    },
    "outputs": [],
    "source": [
-    "from llama_index.tools import FunctionTool\n",
+    "from llama_index.core.tools import FunctionTool\n",
     "from playwright.async_api import async_playwright\n",
     "from tarsier import Tarsier, GoogleVisionOCRService\n",
     "import os\n",
@@ -219,7 +219,7 @@
     "    \"\"\"\n",
     "    x_path = tag_to_xpath[element_id]\n",
     "    print(x_path)\n",
-    "    element = page.locator(x_path)\n",
+    "    element = page.locator(x_path['xpath'])\n",
     "    await element.scroll_into_view_if_needed()\n",
     "    await page.wait_for_timeout(1000)\n",
     "    await element.click()\n",
@@ -236,7 +236,7 @@
     "    \"\"\"\n",
     "    x_path = tag_to_xpath[element_id]\n",
     "    print(x_path)\n",
-    "    await page.locator(x_path).press_sequentially(text)\n",
+    "    await page.locator(x_path['xpath']).press_sequentially(text)\n",
     "    return await read_page()\n",
     "\n",
     "\n",
@@ -276,10 +276,10 @@
    },
    "outputs": [],
    "source": [
-    "from llama_index.agent import OpenAIAgent\n",
-    "from llama_index.llms import OpenAI\n",
+    "from llama_index.agent.openai import OpenAIAgent\n",
+    "from llama_index.llms.openai import OpenAI\n",
     "\n",
-    "llm = OpenAI(model=\"gpt-4\")\n",
+    "llm = OpenAI(model=\"gpt-4o\")\n",
     "tarsier_agent = OpenAIAgent.from_tools(\n",
     "    [read_page_tool, click_tool, type_text_tool, press_key_tool],\n",
     "    llm=llm,\n",
@@ -585,7 +585,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
### Error 1
```
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
Cell In[2], line 1
----> 1 from llama_index.tools import FunctionTool
      2 from playwright.async_api import async_playwright
      3 from tarsier import Tarsier, GoogleVisionOCRService

ModuleNotFoundError: No module named 'llama_index.tools'
```
### Changes:
- Changed `from llama_index.tools import FunctionTool` to `from llama_index.core.tools import FunctionTool`


### Error 2
```
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
Cell In[5], line 1
----> 1 from llama_index.agent import OpenAIAgent
      2 from llama_index.llms import OpenAI
      4 llm = OpenAI(model="gpt-4")

ImportError: cannot import name 'OpenAIAgent' from 'llama_index.agent' (unknown location)
```
### Changes:
- Changed OpenAI import statements 
 

### Error 3
```
Error: Locator.press_sequentially: selector: expected string, got object
``` 
- `element = page.locator(x_path)` -> `element = page.locator(x_path['xpath'])`

### Additional
- Changed the default example model from gpt-4 to gpt-4o since it has much better performance and is cheaper. 
- These changes work with Python version 3.12.7.